### PR TITLE
Add jQuery Cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Plugin and theme authors are told they should prefix all of the handles when enq
 
 I have started with a few. I am not sure how the Google Web Fonts should be best labelled as there are so many variations.
 
+### Cycle
+```php
+wp_enqueue_script( 'jquery-cycle', get_template_directory_uri() . '/js/jquery.cycle2.js', array( 'jquery' ), '2.1.6', true );
+wp_enqueue_script( 'jquery-cycle', plugin_dir_url( __FILE__ ) . '/js/jquery.cycle2.js', array( 'jquery' ), '2.1.6', true );
+```
+
 ### Font Awesome
 ```php
 wp_enqueue_style( 'font-awesome', get_template_directory_uri() . '/css/font-awesome.min.css', array(), '4.2.0', 'all' );


### PR DESCRIPTION
Hi @grappler. Should we leave the handle as I've done it now or should we make the handle specific to cycle2?

--

If you have a moment, perhaps you could check out my question here: https://github.com/grappler/wp-standard-handles/issues/13. This came up when we submitted the latest SiteOrigin theme for review. I also see in Penguin you're prefixing with the theme slug. Thanks :)